### PR TITLE
packages: bump iota lib version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^2.3.0",
-    "iota.lib.js": "^0.2.6",
+    "iota.lib.js": "^0.4.7",
     "mqtt": "^2.6.2",
     "node-cleanup": "^2.1.2",
     "url": "^0.11.0"


### PR DESCRIPTION
The current iota lib is using an unsupported API version, so let update.

Signed-off-by: Tyler Baker <tyler@opensourcefoundries.com>